### PR TITLE
refactor: remove functions without data

### DIFF
--- a/solidity/contracts/OracleAggregator.sol
+++ b/solidity/contracts/OracleAggregator.sol
@@ -56,26 +56,12 @@ contract OracleAggregator is AccessControl, Multicall, IOracleAggregator {
   function quote(
     address _tokenIn,
     uint256 _amountIn,
-    address _tokenOut
-  ) external view returns (uint256 _amountOut) {
-    return quote(_tokenIn, _amountIn, _tokenOut, '');
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function quote(
-    address _tokenIn,
-    uint256 _amountIn,
     address _tokenOut,
     bytes memory _data
   ) public view returns (uint256 _amountOut) {
     ITokenPriceOracle _oracle = assignedOracle(_tokenIn, _tokenOut).oracle;
     if (address(_oracle) == address(0)) revert PairNotSupportedYet(_tokenIn, _tokenOut);
     return _oracle.quote(_tokenIn, _amountIn, _tokenOut, _data);
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function addOrModifySupportForPair(address _tokenA, address _tokenB) external {
-    addOrModifySupportForPair(_tokenA, _tokenB, '');
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -95,11 +81,6 @@ contract OracleAggregator is AccessControl, Multicall, IOracleAggregator {
     if (_shouldModify) {
       _addOrModifySupportForPair(__tokenA, __tokenB, _data);
     }
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function addSupportForPairIfNeeded(address _tokenA, address _tokenB) external {
-    addSupportForPairIfNeeded(_tokenA, _tokenB, '');
   }
 
   /// @inheritdoc ITokenPriceOracle

--- a/solidity/contracts/adapters/StatefulChainlinkOracleAdapter.sol
+++ b/solidity/contracts/adapters/StatefulChainlinkOracleAdapter.sol
@@ -33,24 +33,10 @@ contract StatefulChainlinkOracleAdapter is ITokenPriceOracle {
   function quote(
     address _tokenIn,
     uint256 _amountIn,
-    address _tokenOut
-  ) public view returns (uint256 _amountOut) {
-    return CHAINLINK_ORACLE.quote(_tokenIn, _amountIn.toUint128(), _tokenOut);
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function quote(
-    address _tokenIn,
-    uint256 _amountIn,
     address _tokenOut,
     bytes calldata
   ) external view returns (uint256 _amountOut) {
-    return quote(_tokenIn, _amountIn, _tokenOut);
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function addOrModifySupportForPair(address _tokenA, address _tokenB) public {
-    CHAINLINK_ORACLE.reconfigureSupportForPair(_tokenA, _tokenB);
+    return CHAINLINK_ORACLE.quote(_tokenIn, _amountIn.toUint128(), _tokenOut);
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -59,12 +45,7 @@ contract StatefulChainlinkOracleAdapter is ITokenPriceOracle {
     address _tokenB,
     bytes calldata
   ) external {
-    addOrModifySupportForPair(_tokenA, _tokenB);
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function addSupportForPairIfNeeded(address _tokenA, address _tokenB) public {
-    CHAINLINK_ORACLE.addSupportForPairIfNeeded(_tokenA, _tokenB);
+    CHAINLINK_ORACLE.reconfigureSupportForPair(_tokenA, _tokenB);
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -73,6 +54,6 @@ contract StatefulChainlinkOracleAdapter is ITokenPriceOracle {
     address _tokenB,
     bytes calldata
   ) external {
-    addSupportForPairIfNeeded(_tokenA, _tokenB);
+    CHAINLINK_ORACLE.addSupportForPairIfNeeded(_tokenA, _tokenB);
   }
 }

--- a/solidity/contracts/adapters/UniswapV3Adapter.sol
+++ b/solidity/contracts/adapters/UniswapV3Adapter.sol
@@ -71,27 +71,12 @@ contract UniswapV3Adapter is AccessControl, IUniswapV3Adapter {
   function quote(
     address _tokenIn,
     uint256 _amountIn,
-    address _tokenOut
-  ) public view returns (uint256 _amountOut) {
-    address[] memory _pools = _poolsForPair[_keyForPair(_tokenIn, _tokenOut)];
-    if (_pools.length == 0) revert PairNotSupportedYet(_tokenIn, _tokenOut);
-    return UNISWAP_V3_ORACLE.quoteSpecificPoolsWithTimePeriod(_amountIn.toUint128(), _tokenIn, _tokenOut, _pools, period);
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function quote(
-    address _tokenIn,
-    uint256 _amountIn,
     address _tokenOut,
     bytes calldata
   ) external view returns (uint256) {
-    return quote(_tokenIn, _amountIn, _tokenOut);
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function addOrModifySupportForPair(address _tokenA, address _tokenB) public {
-    delete _poolsForPair[_keyForPair(_tokenA, _tokenB)];
-    _addOrModifySupportForPair(_tokenA, _tokenB);
+    address[] memory _pools = _poolsForPair[_keyForPair(_tokenIn, _tokenOut)];
+    if (_pools.length == 0) revert PairNotSupportedYet(_tokenIn, _tokenOut);
+    return UNISWAP_V3_ORACLE.quoteSpecificPoolsWithTimePeriod(_amountIn.toUint128(), _tokenIn, _tokenOut, _pools, period);
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -100,14 +85,8 @@ contract UniswapV3Adapter is AccessControl, IUniswapV3Adapter {
     address _tokenB,
     bytes calldata
   ) external {
-    addOrModifySupportForPair(_tokenA, _tokenB);
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function addSupportForPairIfNeeded(address _tokenA, address _tokenB) public {
-    if (!isPairAlreadySupported(_tokenA, _tokenB)) {
-      _addOrModifySupportForPair(_tokenA, _tokenB);
-    }
+    delete _poolsForPair[_keyForPair(_tokenA, _tokenB)];
+    _addOrModifySupportForPair(_tokenA, _tokenB);
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -116,7 +95,9 @@ contract UniswapV3Adapter is AccessControl, IUniswapV3Adapter {
     address _tokenB,
     bytes calldata
   ) external {
-    addSupportForPairIfNeeded(_tokenA, _tokenB);
+    if (!isPairAlreadySupported(_tokenA, _tokenB)) {
+      _addOrModifySupportForPair(_tokenA, _tokenB);
+    }
   }
 
   /// @inheritdoc IUniswapV3Adapter

--- a/solidity/interfaces/ITokenPriceOracle.sol
+++ b/solidity/interfaces/ITokenPriceOracle.sol
@@ -31,28 +31,13 @@ interface ITokenPriceOracle {
   function isPairAlreadySupported(address tokenA, address tokenB) external view returns (bool);
 
   /**
-   * @notice Returns a quote, based on the given tokens and amount. Can be consider the same as
-   *         calling `quote(tokenIn, amountIn, tokenOut, data)` with empty data
-   * @dev Will revert if pair isn't supported
-   * @param tokenIn The token that will be provided
-   * @param amountIn The amount that will be provided
-   * @param tokenOut The token we would like to quote
-   * @return amountOut How much `tokenOut` will be returned in exchange for `amountIn` amount of `tokenIn`
-   */
-  function quote(
-    address tokenIn,
-    uint256 amountIn,
-    address tokenOut
-  ) external view returns (uint256 amountOut);
-
-  /**
    * @notice Returns a quote, based on the given tokens and amount
    * @dev Will revert if pair isn't supported
    * @param tokenIn The token that will be provided
    * @param amountIn The amount that will be provided
    * @param tokenOut The token we would like to quote
-   * @return amountOut How much `tokenOut` will be returned in exchange for `amountIn` amount of `tokenIn`
    * @param data Custom data that the oracle might need to operate
+   * @return amountOut How much `tokenOut` will be returned in exchange for `amountIn` amount of `tokenIn`
    */
   function quote(
     address tokenIn,
@@ -60,17 +45,6 @@ interface ITokenPriceOracle {
     address tokenOut,
     bytes calldata data
   ) external view returns (uint256 amountOut);
-
-  /**
-   * @notice Add or reconfigures the support for a given pair. This function will let the oracle take some actions
-   *         to configure the pair, in preparation for future quotes. Can be called many times in order to let the oracle
-   *         re-configure for a new context. Can be consider the same as calling `addOrModifySupportForPair(tokenA, tokenB, data)`
-   *         with empty data.
-   * @dev Will revert if pair cannot be supported. tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
-   * @param tokenA One of the pair's tokens
-   * @param tokenB The other of the pair's tokens
-   */
-  function addOrModifySupportForPair(address tokenA, address tokenB) external;
 
   /**
    * @notice Add or reconfigures the support for a given pair. This function will let the oracle take some actions
@@ -86,17 +60,6 @@ interface ITokenPriceOracle {
     address tokenB,
     bytes calldata data
   ) external;
-
-  /**
-   * @notice Adds support for a given pair if the oracle didn't support it already. If called for a pair that is already supported,
-   *         then nothing will happen. This function will let the oracle take some actions to configure the pair, in preparation
-   *         for future quotes. Can be consider the same as calling `addSupportForPairIfNeeded(tokenA, tokenB, data)` with empty
-   *         data
-   * @dev Will revert if pair cannot be supported. tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
-   * @param tokenA One of the pair's tokens
-   * @param tokenB The other of the pair's tokens
-   */
-  function addSupportForPairIfNeeded(address tokenA, address tokenB) external;
 
   /**
    * @notice Adds support for a given pair if the oracle didn't support it already. If called for a pair that is already supported,

--- a/test/e2e/oracle-aggregator.spec.ts
+++ b/test/e2e/oracle-aggregator.spec.ts
@@ -13,6 +13,7 @@ describe('OracleAggregator', () => {
   const TOKEN_A = '0x0000000000000000000000000000000000000001';
   const TOKEN_B = '0x0000000000000000000000000000000000000002';
   const TOKEN_C = '0x0000000000000000000000000000000000000003';
+  const BYTES = '0xf2c047db4a7cf81f935c'; // Some random bytes
   let superAdmin: SignerWithAddress, admin: SignerWithAddress;
   let oracleAggregator: OracleAggregatorMock;
   let superAdminRole: string, adminRole: string;
@@ -45,7 +46,7 @@ describe('OracleAggregator', () => {
       });
       describe('and then an admin updates the support', () => {
         given(async () => {
-          await oracleAggregator.connect(admin)['addOrModifySupportForPair(address,address)'](TOKEN_A, TOKEN_B);
+          await oracleAggregator.connect(admin).addOrModifySupportForPair(TOKEN_A, TOKEN_B, BYTES);
         });
         then('a oracle that takes precedence will be assigned', async () => {
           const { oracle, forced } = await oracleAggregator.assignedOracle(TOKEN_A, TOKEN_B);
@@ -62,13 +63,13 @@ describe('OracleAggregator', () => {
     when('executing multiple quotes', () => {
       let result1: string, result2: string;
       given(async () => {
-        oracle1['quote(address,uint256,address,bytes)'].returns(QUOTE_ORACLE_1);
-        oracle2['quote(address,uint256,address,bytes)'].returns(QUOTE_ORACLE_2);
+        oracle1.quote.returns(QUOTE_ORACLE_1);
+        oracle2.quote.returns(QUOTE_ORACLE_2);
         await oracleAggregator.connect(admin).forceOracle(TOKEN_A, TOKEN_B, oracle1.address);
         await oracleAggregator.connect(admin).forceOracle(TOKEN_A, TOKEN_C, oracle2.address);
 
-        const { data: quote1Data } = await oracleAggregator.populateTransaction['quote(address,uint256,address)'](TOKEN_A, 1, TOKEN_B);
-        const { data: quote2Data } = await oracleAggregator.populateTransaction['quote(address,uint256,address)'](TOKEN_A, 1, TOKEN_C);
+        const { data: quote1Data } = await oracleAggregator.populateTransaction.quote(TOKEN_A, 1, TOKEN_B, BYTES);
+        const { data: quote2Data } = await oracleAggregator.populateTransaction.quote(TOKEN_A, 1, TOKEN_C, BYTES);
         [result1, result2] = await oracleAggregator.callStatic.multicall([quote1Data!, quote2Data!]);
       });
       then('first quote was returned correctly', async () => {

--- a/test/unit/adapters/stateful-chainlink-oracle-adapter.spec.ts
+++ b/test/unit/adapters/stateful-chainlink-oracle-adapter.spec.ts
@@ -86,10 +86,9 @@ describe('StatefulChainlinkOracleAdapter', () => {
       });
     });
     when('sending the tokens in inverse order', () => {
-      let isAlreadySupported: boolean;
       given(async () => {
         oracle.planForPair.returns(0);
-        isAlreadySupported = await adapter.isPairAlreadySupported(TOKEN_B, TOKEN_A);
+        await adapter.isPairAlreadySupported(TOKEN_B, TOKEN_A);
       });
       then('oracle is called correctly', async () => {
         expect(oracle.planForPair).to.have.been.calledOnceWith(TOKEN_A, TOKEN_B);
@@ -101,7 +100,7 @@ describe('StatefulChainlinkOracleAdapter', () => {
     when('quote amount is over uint128', () => {
       let tx: Promise<BigNumber>;
       given(async () => {
-        tx = adapter['quote(address,uint256,address)'](TOKEN_A, BigNumber.from(2).pow(128), TOKEN_B);
+        tx = adapter.quote(TOKEN_A, BigNumber.from(2).pow(128), TOKEN_B, []);
       });
       then('tx is reverted with reason error', async () => {
         expect(tx).to.have.revertedWith(`SafeCast: value doesn't fit in 128 bits`);
@@ -113,7 +112,7 @@ describe('StatefulChainlinkOracleAdapter', () => {
       let returnedQuote: BigNumber;
       given(async () => {
         oracle.quote.returns(RESULT);
-        returnedQuote = await adapter['quote(address,uint256,address)'](TOKEN_A, MAX_AMOUNT_IN, TOKEN_B);
+        returnedQuote = await adapter.quote(TOKEN_A, MAX_AMOUNT_IN, TOKEN_B, []);
       });
       then('the oracle is called correctly', async () => {
         expect(oracle.quote).to.have.been.calledOnceWith(TOKEN_A, MAX_AMOUNT_IN, TOKEN_B);
@@ -127,7 +126,7 @@ describe('StatefulChainlinkOracleAdapter', () => {
   describe('addOrModifySupportForPair', () => {
     when('adapter is called', () => {
       given(async () => {
-        await adapter['addOrModifySupportForPair(address,address)'](TOKEN_A, TOKEN_B);
+        await adapter.addOrModifySupportForPair(TOKEN_A, TOKEN_B, []);
       });
       then('oracle is called with the same parameters', () => {
         expect(oracle.reconfigureSupportForPair).to.have.been.calledOnceWith(TOKEN_A, TOKEN_B);
@@ -138,7 +137,7 @@ describe('StatefulChainlinkOracleAdapter', () => {
   describe('addSupportForPairIfNeeded', () => {
     when('adapter is called', () => {
       given(async () => {
-        await adapter['addSupportForPairIfNeeded(address,address)'](TOKEN_A, TOKEN_B);
+        await adapter.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B, []);
       });
       then('oracle is called with the same parameters', () => {
         expect(oracle.addSupportForPairIfNeeded).to.have.been.calledOnceWith(TOKEN_A, TOKEN_B);


### PR DESCRIPTION
We've realized that we could simplify our oracles by removing the versions of `quote`, `addOrModifySupportForPair` and `addSupportForPairIfNeeded` that didn't take any custom data.

We are doing this because:
- Oracles will now be simpler to build, test and maintain
- In the cases where oracles needed data, having a function that didn't take any was weird. Should that function fail?

Now, if a oracle doesn't need any custom data, it can just ignore the parameter