### PR TITLE
refactor: implement simple oracle in uni adapter

### DIFF
--- a/solidity/contracts/test/adapters/UniswapV3Adapter.sol
+++ b/solidity/contracts/test/adapters/UniswapV3Adapter.sol
@@ -6,6 +6,14 @@ import '../../adapters/UniswapV3Adapter.sol';
 contract UniswapV3AdapterMock is UniswapV3Adapter {
   constructor(InitialConfig memory _initialConfig) UniswapV3Adapter(_initialConfig) {}
 
+  function internalAddOrModifySupportForPair(
+    address _tokenA,
+    address _tokenB,
+    bytes calldata _data
+  ) external {
+    _addOrModifySupportForPair(_tokenA, _tokenB, _data);
+  }
+
   function setPools(
     address _tokenA,
     address _tokenB,


### PR DESCRIPTION
We are now implementing `SimpleOracle` in the `UniswapV3Adapter`. This change allows us to delete both `addOrModifySupportForPair` and `addSupportForPairIfNeeded`, and their tests. We now just need to implement and test `_addOrModifySupportForPair`

This will make our lives easier moving forward, and everything will be easier to test