### PR TITLE
feat: add transformer oracle

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "@mean-finance/dca-v2-core": "^2.1.0",
     "@mean-finance/deterministic-factory": "1.3.1",
+    "@mean-finance/transformers": "^1.0.0-rc1",
     "@mean-finance/uniswap-v3-oracle": "1.0.0",
     "@openzeppelin/contracts": "4.6.0",
     "@uniswap/v3-core": "1.0.1"

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,5 @@
 {
   "exclude_low": true,
-  "detectors_to_exclude": "conformance-to-solidity-naming-conventions,incorrect-versions-of-solidity,variable-names-are-too-similar",
+  "detectors_to_exclude": "conformance-to-solidity-naming-conventions,incorrect-versions-of-solidity,similar-names,solc-version",
   "filter_paths": "node_modules|openzeppelin|interfaces"
 }

--- a/solidity/contracts/TransformerOracle.sol
+++ b/solidity/contracts/TransformerOracle.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import './base/BaseOracle.sol';
+import '../interfaces/ITransformerOracle.sol';
+
+contract TransformerOracle is BaseOracle, ITransformerOracle {
+  /// @inheritdoc ITransformerOracle
+  ITransformerRegistry public immutable REGISTRY;
+
+  /// @inheritdoc ITransformerOracle
+  ITokenPriceOracle public immutable UNDERLYING_ORACLE;
+
+  constructor(ITransformerRegistry _registry, ITokenPriceOracle _underlyingOracle) {
+    if (address(_registry) == address(0) || address(_underlyingOracle) == address(0)) revert ZeroAddress();
+    REGISTRY = _registry;
+    UNDERLYING_ORACLE = _underlyingOracle;
+  }
+
+  /// @inheritdoc ITokenPriceOracle
+  function canSupportPair(address _tokenA, address _tokenB) external view returns (bool) {
+    // TODO: Implement
+  }
+
+  /// @inheritdoc ITokenPriceOracle
+  function isPairAlreadySupported(address _tokenA, address _tokenB) external view returns (bool) {
+    // TODO: Implement
+  }
+
+  /// @inheritdoc ITokenPriceOracle
+  function quote(
+    address _tokenIn,
+    uint256 _amountIn,
+    address _tokenOut,
+    bytes calldata _data
+  ) external view returns (uint256 _amountOut) {
+    // TODO: Implement
+  }
+
+  /// @inheritdoc ITokenPriceOracle
+  function addOrModifySupportForPair(
+    address _tokenA,
+    address _tokenB,
+    bytes calldata _data
+  ) external {
+    // TODO: Implement
+  }
+
+  /// @inheritdoc ITokenPriceOracle
+  function addSupportForPairIfNeeded(
+    address _tokenA,
+    address _tokenB,
+    bytes calldata _data
+  ) external {
+    // TODO: Implement
+  }
+}

--- a/solidity/interfaces/ITransformerOracle.sol
+++ b/solidity/interfaces/ITransformerOracle.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import '@mean-finance/transformers/solidity/interfaces/ITransformerRegistry.sol';
+import './ITokenPriceOracle.sol';
+
+/**
+ * @title An implementation of `ITokenPriceOracle` that handles transformations between tokens
+ * @notice This oracle takes the transformer registry, and will transform some dependent tokens into their underlying
+ *         tokens before quoting. We do this because it's hard to quote `yield-bearing(USDC) => yield-bearing(ETH)`.
+ *         But we can easily do something like `yield-bearing(USDC) => USDC => ETH => yield-bearing(ETH)`. So the
+ *         idea is to use the tranformer registry to transform between dependent and their underlying, and then
+ *         quote the underlyings.
+ */
+interface ITransformerOracle is ITokenPriceOracle {
+  /// @notice Thrown when a parameter is the zero address
+  error ZeroAddress();
+
+  /**
+   * @notice Returns the address of the transformer registry
+   * @dev Cannot be modified
+   * @return The address of the transformer registry
+   */
+  function REGISTRY() external view returns (ITransformerRegistry);
+
+  /**
+   * @notice Returns the address of the underlying oracle
+   * @dev Cannot be modified
+   * @return The address of the underlying oracle
+   */
+  function UNDERLYING_ORACLE() external view returns (ITokenPriceOracle);
+}

--- a/solidity/interfaces/ITransformerOracle.sol
+++ b/solidity/interfaces/ITransformerOracle.sol
@@ -9,7 +9,7 @@ import './ITokenPriceOracle.sol';
  * @notice This oracle takes the transformer registry, and will transform some dependent tokens into their underlying
  *         tokens before quoting. We do this because it's hard to quote `yield-bearing(USDC) => yield-bearing(ETH)`.
  *         But we can easily do something like `yield-bearing(USDC) => USDC => ETH => yield-bearing(ETH)`. So the
- *         idea is to use the tranformer registry to transform between dependent and their underlying, and then
+ *         idea is to use the transformer registry to transform between dependent and their underlying, and then
  *         quote the underlyings.
  */
 interface ITransformerOracle is ITokenPriceOracle {

--- a/test/unit/transformer-oracle.spec.ts
+++ b/test/unit/transformer-oracle.spec.ts
@@ -1,0 +1,61 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { constants } from 'ethers';
+import { behaviours } from '@utils';
+import { then, when } from '@utils/bdd';
+import { ITransformerRegistry, ITokenPriceOracle, TransformerOracle, TransformerOracle__factory } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { smock, FakeContract } from '@defi-wonderland/smock';
+
+chai.use(smock.matchers);
+
+describe('TransformerOracle', () => {
+  let transformerOracleFactory: TransformerOracle__factory;
+  let transformerOracle: TransformerOracle;
+  let underlyingOracle: FakeContract<ITokenPriceOracle>;
+  let registry: FakeContract<ITransformerRegistry>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    transformerOracleFactory = await ethers.getContractFactory('solidity/contracts/TransformerOracle.sol:TransformerOracle');
+    registry = await smock.fake<ITransformerRegistry>('ITokenPriceOracle');
+    underlyingOracle = await smock.fake<ITokenPriceOracle>('ITokenPriceOracle');
+    transformerOracle = await transformerOracleFactory.deploy(registry.address, underlyingOracle.address);
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach('Deploy and configure', async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('constructor', () => {
+    when('registry is zero address', () => {
+      then('tx is reverted with reason error', async () => {
+        await behaviours.deployShouldRevertWithMessage({
+          contract: transformerOracleFactory,
+          args: [constants.AddressZero, underlyingOracle.address],
+          message: 'ZeroAddress',
+        });
+      });
+    });
+    when('underlying oracle is zero address', () => {
+      then('tx is reverted with reason error', async () => {
+        await behaviours.deployShouldRevertWithMessage({
+          contract: transformerOracleFactory,
+          args: [registry.address, constants.AddressZero],
+          message: 'ZeroAddress',
+        });
+      });
+    });
+    when('all arguments are valid', () => {
+      then('registry is set correctly', async () => {
+        const returnedRegistry = await transformerOracle.REGISTRY();
+        expect(returnedRegistry).to.equal(registry.address);
+      });
+      then('registry is set correctly', async () => {
+        const returnedOracle = await transformerOracle.UNDERLYING_ORACLE();
+        expect(returnedOracle).to.equal(underlyingOracle.address);
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,6 +1201,14 @@
     "@openzeppelin/contracts" "4.6.0"
     "@rari-capital/solmate" "6.2.0"
 
+"@mean-finance/transformers@^1.0.0-rc1":
+  version "1.0.0-rc1"
+  resolved "https://registry.yarnpkg.com/@mean-finance/transformers/-/transformers-1.0.0-rc1.tgz#423d010c0dc803f4607181916526f4a5e01bba29"
+  integrity sha512-4kxuN+CgstKO0yaPvEL8MtTFdIRWowwi3SDWu3/gSeZRkwZOHUyrkNGqT/mXA1cJpKRZhcDDholu7hf2Jd/EzA==
+  dependencies:
+    "@mean-finance/deterministic-factory" "1.3.1"
+    "@openzeppelin/contracts" "^4.7.0-rc.0"
+
 "@mean-finance/uniswap-v3-oracle@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@mean-finance/uniswap-v3-oracle/-/uniswap-v3-oracle-1.0.0.tgz#22c3278883a4c9f64bd4683f5f6b2c91296c4cd3"
@@ -1429,6 +1437,11 @@
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
   integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
+
+"@openzeppelin/contracts@^4.7.0-rc.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.0.tgz#3092d70ea60e3d1835466266b1d68ad47035a2d5"
+  integrity sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw==
 
 "@openzeppelin/test-helpers@^0.5.15":
   version "0.5.15"


### PR DESCRIPTION
We are now adding the transformer oracle contract. Per its description:

> This oracle takes the transformer registry, and will transform some dependent tokens into their underlying tokens before quoting. We do this because it's hard to quote `yield-bearing(USDC) => yield-bearing(ETH)`. But we can easily do something like `yield-bearing(USDC) => USDC => ETH => yield-bearing(ETH)`. So the idea is to use the transformer registry to transform between dependent and their underlying, and then quote the underlyings.