### PR TITLE
feat: add easy redirect calls

### DIFF
--- a/solidity/contracts/TransformerOracle.sol
+++ b/solidity/contracts/TransformerOracle.sol
@@ -1,52 +1,77 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import '@openzeppelin/contracts/access/AccessControl.sol';
 import './base/BaseOracle.sol';
 import '../interfaces/ITransformerOracle.sol';
 
 /**
  * @notice This implementation of `ITransformerOracle` assumes that all tokens being transformed only have one underlying token.
- *         This is true when this implementation was writter, but it may not be true in the future. If that happens, then another
+ *         This is true when this implementation was written, but it may not be true in the future. If that happens, then another
  *         implementation will be needed
  */
-contract TransformerOracle is BaseOracle, ITransformerOracle {
+contract TransformerOracle is BaseOracle, AccessControl, ITransformerOracle {
+  bytes32 public constant SUPER_ADMIN_ROLE = keccak256('SUPER_ADMIN_ROLE');
+  bytes32 public constant ADMIN_ROLE = keccak256('ADMIN_ROLE');
+
   /// @inheritdoc ITransformerOracle
   ITransformerRegistry public immutable REGISTRY;
 
   /// @inheritdoc ITransformerOracle
   ITokenPriceOracle public immutable UNDERLYING_ORACLE;
 
-  constructor(ITransformerRegistry _registry, ITokenPriceOracle _underlyingOracle) {
-    if (address(_registry) == address(0) || address(_underlyingOracle) == address(0)) revert ZeroAddress();
+  /// @inheritdoc ITransformerOracle
+  mapping(address => bool) public willAvoidMappingToUnderlying;
+
+  constructor(
+    ITransformerRegistry _registry,
+    ITokenPriceOracle _underlyingOracle,
+    address _superAdmin,
+    address[] memory _initialAdmins
+  ) {
+    if (address(_registry) == address(0) || address(_underlyingOracle) == address(0) || _superAdmin == address(0)) revert ZeroAddress();
     REGISTRY = _registry;
     UNDERLYING_ORACLE = _underlyingOracle;
+    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
+    _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
+    for (uint256 i; i < _initialAdmins.length; i++) {
+      _setupRole(ADMIN_ROLE, _initialAdmins[i]);
+    }
   }
 
   /// @inheritdoc ITransformerOracle
-  function mapPairToUnderlying(address _tokenA, address _tokenB)
-    public
-    view
-    virtual
-    returns (address _underlyingTokenA, address _underlyingTokenB)
-  {
-    address[] memory _tokens = new address[](2);
-    _tokens[0] = _tokenA;
-    _tokens[1] = _tokenB;
-    ITransformer[] memory _transformers = REGISTRY.transformers(_tokens);
-    _underlyingTokenA = _mapToUnderlyingIfExists(_tokenA, _transformers[0]);
-    _underlyingTokenB = _mapToUnderlyingIfExists(_tokenB, _transformers[1]);
+  function getMappingForPair(address _tokenA, address _tokenB) public view virtual returns (address _mappedTokenA, address _mappedTokenB) {
+    ITransformer[] memory _transformers = _getTransformers(_tokenA, _tokenB);
+    _mappedTokenA = _mapToUnderlyingIfExists(_tokenA, _transformers[0]);
+    _mappedTokenB = _mapToUnderlyingIfExists(_tokenB, _transformers[1]);
+  }
+
+  /// @inheritdoc ITransformerOracle
+  function shouldMapToUnderlying(address[] calldata _dependents) external onlyRole(ADMIN_ROLE) {
+    for (uint256 i; i < _dependents.length; i++) {
+      willAvoidMappingToUnderlying[_dependents[i]] = false;
+    }
+    emit DependentsWillMapToUnderlying(_dependents);
+  }
+
+  /// @inheritdoc ITransformerOracle
+  function avoidMappingToUnderlying(address[] calldata _dependents) external onlyRole(ADMIN_ROLE) {
+    for (uint256 i; i < _dependents.length; i++) {
+      willAvoidMappingToUnderlying[_dependents[i]] = true;
+    }
+    emit DependentsWillAvoidMappingToUnderlying(_dependents);
   }
 
   /// @inheritdoc ITokenPriceOracle
   function canSupportPair(address _tokenA, address _tokenB) external view returns (bool) {
-    (address _underlyingTokenA, address _underlyingTokenB) = mapPairToUnderlying(_tokenA, _tokenB);
-    return UNDERLYING_ORACLE.canSupportPair(_underlyingTokenA, _underlyingTokenB);
+    (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);
+    return UNDERLYING_ORACLE.canSupportPair(_mappedTokenA, _mappedTokenB);
   }
 
   /// @inheritdoc ITokenPriceOracle
   function isPairAlreadySupported(address _tokenA, address _tokenB) external view returns (bool) {
-    (address _underlyingTokenA, address _underlyingTokenB) = mapPairToUnderlying(_tokenA, _tokenB);
-    return UNDERLYING_ORACLE.isPairAlreadySupported(_underlyingTokenA, _underlyingTokenB);
+    (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);
+    return UNDERLYING_ORACLE.isPairAlreadySupported(_mappedTokenA, _mappedTokenB);
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -56,7 +81,28 @@ contract TransformerOracle is BaseOracle, ITransformerOracle {
     address _tokenOut,
     bytes calldata _data
   ) external view returns (uint256 _amountOut) {
-    // TODO: Implement
+    ITransformer[] memory _transformers = _getTransformers(_tokenIn, _tokenOut);
+    ITransformer _transformerTokenIn = _transformers[0];
+    ITransformer _transformerTokenOut = _transformers[1];
+    if (address(_transformerTokenIn) != address(0) && address(_transformerTokenOut) != address(0)) {
+      // If both tokens have a transformer, then we need to transform both in and out data
+      ITransformer.UnderlyingAmount[] memory _transformedIn = _transformerTokenIn.calculateTransformToUnderlying(_tokenIn, _amountIn);
+      address[] memory _underlyingOut = _transformerTokenOut.getUnderlying(_tokenOut);
+      uint256 _amountOutUnderlying = UNDERLYING_ORACLE.quote(_transformedIn[0].underlying, _transformedIn[0].amount, _underlyingOut[0], _data);
+      return _transformerTokenOut.calculateTransformToDependent(_tokenOut, _toUnderlyingAmount(_underlyingOut[0], _amountOutUnderlying));
+    } else if (address(_transformerTokenIn) != address(0)) {
+      // If token in has a transformer, then calculate how much amount it would be in underlying, and calculate the quote for that
+      ITransformer.UnderlyingAmount[] memory _transformedIn = _transformerTokenIn.calculateTransformToUnderlying(_tokenIn, _amountIn);
+      return UNDERLYING_ORACLE.quote(_transformedIn[0].underlying, _transformedIn[0].amount, _tokenOut, _data);
+    } else if (address(_transformerTokenOut) != address(0)) {
+      // If token out has a transformer, then calculate the quote for the underlying and then transform the result
+      address[] memory _underlyingOut = _transformerTokenOut.getUnderlying(_tokenOut);
+      uint256 _amountOutUnderlying = UNDERLYING_ORACLE.quote(_tokenIn, _amountIn, _underlyingOut[0], _data);
+      return _transformerTokenOut.calculateTransformToDependent(_tokenOut, _toUnderlyingAmount(_underlyingOut[0], _amountOutUnderlying));
+    } else {
+      // If there are no transformers, then just call the underlying oracle
+      return UNDERLYING_ORACLE.quote(_tokenIn, _amountIn, _tokenOut, _data);
+    }
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -65,8 +111,8 @@ contract TransformerOracle is BaseOracle, ITransformerOracle {
     address _tokenB,
     bytes calldata _data
   ) external {
-    (address _underlyingTokenA, address _underlyingTokenB) = mapPairToUnderlying(_tokenA, _tokenB);
-    UNDERLYING_ORACLE.addOrModifySupportForPair(_underlyingTokenA, _underlyingTokenB, _data);
+    (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);
+    UNDERLYING_ORACLE.addOrModifySupportForPair(_mappedTokenA, _mappedTokenB, _data);
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -75,13 +121,16 @@ contract TransformerOracle is BaseOracle, ITransformerOracle {
     address _tokenB,
     bytes calldata _data
   ) external {
-    (address _underlyingTokenA, address _underlyingTokenB) = mapPairToUnderlying(_tokenA, _tokenB);
-    UNDERLYING_ORACLE.addSupportForPairIfNeeded(_underlyingTokenA, _underlyingTokenB, _data);
+    (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);
+    UNDERLYING_ORACLE.addSupportForPairIfNeeded(_mappedTokenA, _mappedTokenB, _data);
   }
 
   /// @inheritdoc IERC165
-  function supportsInterface(bytes4 _interfaceId) public view override returns (bool) {
-    return _interfaceId == type(ITransformerOracle).interfaceId || super.supportsInterface(_interfaceId);
+  function supportsInterface(bytes4 _interfaceId) public view override(AccessControl, BaseOracle) returns (bool) {
+    return
+      _interfaceId == type(ITransformerOracle).interfaceId ||
+      AccessControl.supportsInterface(_interfaceId) ||
+      BaseOracle.supportsInterface(_interfaceId);
   }
 
   /**
@@ -94,5 +143,44 @@ contract TransformerOracle is BaseOracle, ITransformerOracle {
     }
     address[] memory _underlying = _transformer.getUnderlying(_token);
     return _underlying[0];
+  }
+
+  function _getTransformers(address _tokenA, address _tokenB) internal view virtual returns (ITransformer[] memory _transformers) {
+    bool _avoidMappingA = willAvoidMappingToUnderlying[_tokenA];
+    bool _avoidMappingB = willAvoidMappingToUnderlying[_tokenB];
+    if (!_avoidMappingA && !_avoidMappingB) {
+      address[] memory _tokens = new address[](2);
+      _tokens[0] = _tokenA;
+      _tokens[1] = _tokenB;
+      return REGISTRY.transformers(_tokens);
+    } else {
+      _transformers = new ITransformer[](2);
+      if (_avoidMappingA && _avoidMappingB) {
+        _transformers[0] = ITransformer(address(0));
+        _transformers[1] = ITransformer(address(0));
+      } else if (_avoidMappingA) {
+        _transformers[0] = ITransformer(address(0));
+        address[] memory _tokens = new address[](1);
+        _tokens[0] = _tokenB;
+        ITransformer[] memory _returnedTransformers = REGISTRY.transformers(_tokens);
+        _transformers[1] = _returnedTransformers[0];
+      } else {
+        address[] memory _tokens = new address[](1);
+        _tokens[0] = _tokenA;
+        ITransformer[] memory _returnedTransformers = REGISTRY.transformers(_tokens);
+        _transformers[0] = _returnedTransformers[0];
+        _transformers[1] = ITransformer(address(0));
+      }
+    }
+  }
+
+  function _toUnderlyingAmount(address _underlying, uint256 _amount)
+    internal
+    pure
+    returns (ITransformer.UnderlyingAmount[] memory _underlyingAmount)
+  {
+    _underlyingAmount = new ITransformer.UnderlyingAmount[](1);
+    _underlyingAmount[0].underlying = _underlying;
+    _underlyingAmount[0].amount = _amount;
   }
 }

--- a/solidity/contracts/TransformerOracle.sol
+++ b/solidity/contracts/TransformerOracle.sol
@@ -23,7 +23,12 @@ contract TransformerOracle is BaseOracle, ITransformerOracle {
   }
 
   /// @inheritdoc ITransformerOracle
-  function mapPairToUnderlying(address _tokenA, address _tokenB) public view returns (address _underlyingTokenA, address _underlyingTokenB) {
+  function mapPairToUnderlying(address _tokenA, address _tokenB)
+    public
+    view
+    virtual
+    returns (address _underlyingTokenA, address _underlyingTokenB)
+  {
     address[] memory _tokens = new address[](2);
     _tokens[0] = _tokenA;
     _tokens[1] = _tokenB;
@@ -34,12 +39,14 @@ contract TransformerOracle is BaseOracle, ITransformerOracle {
 
   /// @inheritdoc ITokenPriceOracle
   function canSupportPair(address _tokenA, address _tokenB) external view returns (bool) {
-    // TODO: Implement
+    (address _underlyingTokenA, address _underlyingTokenB) = mapPairToUnderlying(_tokenA, _tokenB);
+    return UNDERLYING_ORACLE.canSupportPair(_underlyingTokenA, _underlyingTokenB);
   }
 
   /// @inheritdoc ITokenPriceOracle
   function isPairAlreadySupported(address _tokenA, address _tokenB) external view returns (bool) {
-    // TODO: Implement
+    (address _underlyingTokenA, address _underlyingTokenB) = mapPairToUnderlying(_tokenA, _tokenB);
+    return UNDERLYING_ORACLE.isPairAlreadySupported(_underlyingTokenA, _underlyingTokenB);
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -58,7 +65,8 @@ contract TransformerOracle is BaseOracle, ITransformerOracle {
     address _tokenB,
     bytes calldata _data
   ) external {
-    // TODO: Implement
+    (address _underlyingTokenA, address _underlyingTokenB) = mapPairToUnderlying(_tokenA, _tokenB);
+    UNDERLYING_ORACLE.addOrModifySupportForPair(_underlyingTokenA, _underlyingTokenB, _data);
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -67,7 +75,8 @@ contract TransformerOracle is BaseOracle, ITransformerOracle {
     address _tokenB,
     bytes calldata _data
   ) external {
-    // TODO: Implement
+    (address _underlyingTokenA, address _underlyingTokenB) = mapPairToUnderlying(_tokenA, _tokenB);
+    UNDERLYING_ORACLE.addSupportForPairIfNeeded(_underlyingTokenA, _underlyingTokenB, _data);
   }
 
   /// @inheritdoc IERC165

--- a/solidity/contracts/test/TransformerOracle.sol
+++ b/solidity/contracts/test/TransformerOracle.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../TransformerOracle.sol';
+
+contract TransformerOracleMock is TransformerOracle {
+  mapping(address => mapping(address => address[])) internal _underlyingPair;
+
+  constructor(ITransformerRegistry _registry, ITokenPriceOracle _underlyingOracle) TransformerOracle(_registry, _underlyingOracle) {}
+
+  function setUnderlying(
+    address _tokenA,
+    address _tokenB,
+    address _underlyingTokenA,
+    address _underlyingTokenB
+  ) external {
+    _underlyingPair[_tokenA][_tokenB].push(_underlyingTokenA);
+    _underlyingPair[_tokenA][_tokenB].push(_underlyingTokenB);
+  }
+
+  function mapPairToUnderlying(address _tokenA, address _tokenB)
+    public
+    view
+    override
+    returns (address _underlyingTokenA, address _underlyingTokenB)
+  {
+    address[] memory _underlying = _underlyingPair[_tokenA][_tokenB];
+    if (_underlying.length == 0) {
+      return super.mapPairToUnderlying(_tokenA, _tokenB);
+    } else {
+      return (_underlying[0], _underlying[1]);
+    }
+  }
+}

--- a/solidity/interfaces/ITransformerOracle.sol
+++ b/solidity/interfaces/ITransformerOracle.sol
@@ -17,6 +17,18 @@ interface ITransformerOracle is ITokenPriceOracle {
   error ZeroAddress();
 
   /**
+   * @notice Emitted when new dependents are set to avoid mapping to their underlying counterparts
+   * @param dependents The tokens that will avoid mapping
+   */
+  event DependentsWillAvoidMappingToUnderlying(address[] dependents);
+
+  /**
+   * @notice Emitted when dependents are set to map to their underlying counterparts
+   * @param dependents The tokens that will map to underlying
+   */
+  event DependentsWillMapToUnderlying(address[] dependents);
+
+  /**
    * @notice Returns the address of the transformer registry
    * @dev Cannot be modified
    * @return The address of the transformer registry
@@ -31,13 +43,36 @@ interface ITransformerOracle is ITokenPriceOracle {
   function UNDERLYING_ORACLE() external view returns (ITokenPriceOracle);
 
   /**
-   * @notice Takes a pair of tokens, and checks if any of them is registered as a dependent on the registry.
-   *         If any of them are, then they are transformed to their underlying tokens. If they aren't, then
-   *         they are simply returned
+   * @notice Returns whether the given dependent will avoid mapping to their underlying counterparts
+   * @param dependent The dependent token to check
+   * @return Whether the given dependent will avoid mapping to their underlying counterparts
+   */
+  function willAvoidMappingToUnderlying(address dependent) external view returns (bool);
+
+  /**
+   * @notice Takes a pair of tokens, and maps them to their underlying counterparts if they exist, and if they
+   *         haven't been configured to avoid mapping
    * @param tokenA One of the pair's tokens
    * @param tokenB The other of the pair's tokens
-   * @return underlyingTokenA tokenA's underlying token (if exists), or tokenA if there is no underlying token
-   * @return underlyingTokenB tokenB's underlying token (if exists), or tokenB if there is no underlying token
+   * @return mappedTokenA tokenA's underlying token, if exists and isn't configured to avoid mapping.
+   *                      Otherwise tokenA
+   * @return mappedTokenB tokenB's underlying token, if exists and isn't configured to avoid mapping.
+   *                      Otherwise tokenB
    */
-  function mapPairToUnderlying(address tokenA, address tokenB) external view returns (address underlyingTokenA, address underlyingTokenB);
+  function getMappingForPair(address tokenA, address tokenB) external view returns (address mappedTokenA, address mappedTokenB);
+
+  /**
+   * @notice Determines that the given dependents will avoid mapping to their underlying counterparts, and
+   *         instead perform quotes with their own addreses. This comes in handy with situations such as
+   *         ETH/WETH, where some oracles use WETH instead of ETH
+   * @param dependents The dependent tokens that should avoid mapping to underlying
+   */
+  function avoidMappingToUnderlying(address[] calldata dependents) external;
+
+  /**
+   * @notice Determines that the given dependents go back to mapping to their underlying counterparts (the
+   *         default behaviour)
+   * @param dependents The dependent tokens that should go back to mapping to underlying
+   */
+  function shouldMapToUnderlying(address[] calldata dependents) external;
 }

--- a/test/unit/transformer-oracle.spec.ts
+++ b/test/unit/transformer-oracle.spec.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { constants } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 import { behaviours } from '@utils';
 import { given, then, when } from '@utils/bdd';
 import {
@@ -14,9 +14,12 @@ import {
   ITransformerOracle__factory,
   IERC20__factory,
   ITransformer,
+  IAccessControl__factory,
 } from '@typechained';
 import { snapshot } from '@utils/evm';
 import { smock, FakeContract } from '@defi-wonderland/smock';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { TransactionResponse } from '@ethersproject/providers';
 
 chai.use(smock.matchers);
 
@@ -27,20 +30,25 @@ describe('TransformerOracle', () => {
   const UNDERLYING_TOKEN_B = '0x0000000000000000000000000000000000000004';
   const BYTES = '0xf2c047db4a7cf81f935c'; // Some random bytes
 
+  let superAdmin: SignerWithAddress, admin: SignerWithAddress;
   let transformerOracleFactory: TransformerOracleMock__factory;
   let transformerOracle: TransformerOracleMock;
   let underlyingOracle: FakeContract<ITokenPriceOracle>;
   let registry: FakeContract<ITransformerRegistry>;
   let transformerA: FakeContract<ITransformer>, transformerB: FakeContract<ITransformer>;
+  let superAdminRole: string, adminRole: string;
   let snapshotId: string;
 
   before('Setup accounts and contracts', async () => {
+    [, superAdmin, admin] = await ethers.getSigners();
     transformerOracleFactory = await ethers.getContractFactory('solidity/contracts/test/TransformerOracle.sol:TransformerOracleMock');
     registry = await smock.fake<ITransformerRegistry>('ITransformerRegistry');
     underlyingOracle = await smock.fake<ITokenPriceOracle>('ITokenPriceOracle');
     transformerA = await smock.fake<ITransformer>('ITransformer');
     transformerB = await smock.fake<ITransformer>('ITransformer');
-    transformerOracle = await transformerOracleFactory.deploy(registry.address, underlyingOracle.address);
+    transformerOracle = await transformerOracleFactory.deploy(registry.address, underlyingOracle.address, superAdmin.address, [admin.address]);
+    superAdminRole = await transformerOracle.SUPER_ADMIN_ROLE();
+    adminRole = await transformerOracle.ADMIN_ROLE();
     snapshotId = await snapshot.take();
   });
 
@@ -50,9 +58,12 @@ describe('TransformerOracle', () => {
     underlyingOracle.isPairAlreadySupported.reset();
     underlyingOracle.addOrModifySupportForPair.reset();
     underlyingOracle.addSupportForPairIfNeeded.reset();
+    underlyingOracle.quote.reset();
     registry.transformers.reset();
     transformerA.getUnderlying.reset();
     transformerB.getUnderlying.reset();
+    transformerA.calculateTransformToUnderlying.reset();
+    transformerB.calculateTransformToDependent.reset();
     transformerA.getUnderlying.returns([UNDERLYING_TOKEN_A]);
     transformerB.getUnderlying.returns([UNDERLYING_TOKEN_B]);
   });
@@ -62,7 +73,7 @@ describe('TransformerOracle', () => {
       then('tx is reverted with reason error', async () => {
         await behaviours.deployShouldRevertWithMessage({
           contract: transformerOracleFactory,
-          args: [constants.AddressZero, underlyingOracle.address],
+          args: [constants.AddressZero, underlyingOracle.address, superAdmin.address, [admin.address]],
           message: 'ZeroAddress',
         });
       });
@@ -71,8 +82,17 @@ describe('TransformerOracle', () => {
       then('tx is reverted with reason error', async () => {
         await behaviours.deployShouldRevertWithMessage({
           contract: transformerOracleFactory,
-          args: [registry.address, constants.AddressZero],
+          args: [registry.address, constants.AddressZero, superAdmin.address, [admin.address]],
           message: 'ZeroAddress',
+        });
+      });
+      when('super admin is zero address', () => {
+        then('tx is reverted with reason error', async () => {
+          await behaviours.deployShouldRevertWithMessage({
+            contract: transformerOracleFactory,
+            args: [registry.address, underlyingOracle.address, constants.AddressZero, [admin.address]],
+            message: 'ZeroAddress',
+          });
         });
       });
     });
@@ -85,35 +105,47 @@ describe('TransformerOracle', () => {
         const returnedOracle = await transformerOracle.UNDERLYING_ORACLE();
         expect(returnedOracle).to.equal(underlyingOracle.address);
       });
+      then('super admin is set correctly', async () => {
+        const hasRole = await transformerOracle.hasRole(superAdminRole, superAdmin.address);
+        expect(hasRole).to.be.true;
+      });
+      then('initial admins are set correctly', async () => {
+        const hasRole = await transformerOracle.hasRole(adminRole, admin.address);
+        expect(hasRole).to.be.true;
+      });
+      then('super admin role is set as admin role', async () => {
+        const admin = await transformerOracle.getRoleAdmin(adminRole);
+        expect(admin).to.equal(superAdminRole);
+      });
     });
   });
 
-  describe('mapPairToUnderlying', () => {
-    mapPairToUnderlyingTest({
+  describe('getMappingForPair', () => {
+    getMappingForPairTest({
       when: 'both tokens have underlying',
       underlyingTokenA: true,
       underlyingTokenB: true,
     });
 
-    mapPairToUnderlyingTest({
+    getMappingForPairTest({
       when: 'only tokenA has underlying',
       underlyingTokenA: true,
       underlyingTokenB: false,
     });
 
-    mapPairToUnderlyingTest({
+    getMappingForPairTest({
       when: 'only tokenB has underlying',
       underlyingTokenA: false,
       underlyingTokenB: true,
     });
 
-    mapPairToUnderlyingTest({
+    getMappingForPairTest({
       when: 'neither of the tokens have underlying',
       underlyingTokenA: false,
       underlyingTokenB: false,
     });
 
-    function mapPairToUnderlyingTest({
+    function getMappingForPairTest({
       when: title,
       underlyingTokenA: tokenAHasUnderlying,
       underlyingTokenB: tokenBHasUnderlying,
@@ -123,26 +155,23 @@ describe('TransformerOracle', () => {
       underlyingTokenB: boolean;
     }) {
       when(title, () => {
-        let underlyingTokenA: string, underlyingTokenB: string;
+        let mappedTokenA: string, mappedTokenB: string;
         given(async () => {
           const transformerTokenA = tokenAHasUnderlying ? transformerA.address : constants.AddressZero;
           const transformerTokenB = tokenBHasUnderlying ? transformerB.address : constants.AddressZero;
-          registry.transformers.returns([transformerTokenA, transformerTokenB]);
-          [underlyingTokenA, underlyingTokenB] = await transformerOracle.mapPairToUnderlying(TOKEN_A, TOKEN_B);
-        });
-        then('registry was called correctly', () => {
-          expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_A, TOKEN_B]);
+          await transformerOracle.setTransformersForPair(TOKEN_A, TOKEN_B, transformerTokenA, transformerTokenB);
+          [mappedTokenA, mappedTokenB] = await transformerOracle.getMappingForPair(TOKEN_A, TOKEN_B);
         });
         if (tokenAHasUnderlying) {
           then('underlying tokenA is returned correctly', () => {
-            expect(underlyingTokenA).to.equal(UNDERLYING_TOKEN_A);
+            expect(mappedTokenA).to.equal(UNDERLYING_TOKEN_A);
           });
           then('transformer for tokenA was called correctly', () => {
             expect(transformerA.getUnderlying).to.have.been.calledOnceWith(TOKEN_A);
           });
         } else {
-          then('underlying for tokenA is actually tokenA', () => {
-            expect(underlyingTokenA).to.equal(TOKEN_A);
+          then('mapped for tokenA is actually tokenA', () => {
+            expect(mappedTokenA).to.equal(TOKEN_A);
           });
           then('transformer for tokenA was not called', () => {
             expect(transformerA.getUnderlying).to.not.have.been.called;
@@ -150,14 +179,14 @@ describe('TransformerOracle', () => {
         }
         if (tokenBHasUnderlying) {
           then('underlying tokenB is returned correctly', () => {
-            expect(underlyingTokenB).to.equal(UNDERLYING_TOKEN_B);
+            expect(mappedTokenB).to.equal(UNDERLYING_TOKEN_B);
           });
           then('transformer for tokenB was called correctly', () => {
             expect(transformerB.getUnderlying).to.have.been.calledOnceWith(TOKEN_B);
           });
         } else {
-          then('underlying for tokenB is actually tokenB', () => {
-            expect(underlyingTokenB).to.equal(TOKEN_B);
+          then('mapped for tokenB is actually tokenB', () => {
+            expect(mappedTokenB).to.equal(TOKEN_B);
           });
           then('transformer for tokenB was not called', () => {
             expect(transformerB.getUnderlying).to.not.have.been.called;
@@ -165,6 +194,53 @@ describe('TransformerOracle', () => {
         }
       });
     }
+  });
+
+  describe('avoidMappingToUnderlying', () => {
+    when('token is set to avoid mapping', () => {
+      let tx: TransactionResponse;
+      given(async () => {
+        tx = await transformerOracle.connect(admin).avoidMappingToUnderlying([TOKEN_A]);
+      });
+      then('token will avoid mapping', async () => {
+        const willAvoid = await transformerOracle.willAvoidMappingToUnderlying(TOKEN_A);
+        expect(willAvoid).to.be.true;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(transformerOracle, 'DependentsWillAvoidMappingToUnderlying').withArgs([TOKEN_A]);
+      });
+    });
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => transformerOracle,
+      funcAndSignature: 'avoidMappingToUnderlying',
+      params: [[TOKEN_A]],
+      addressWithRole: () => admin,
+      role: () => adminRole,
+    });
+  });
+
+  describe('shouldMapToUnderlying', () => {
+    when('token is set to map again', () => {
+      let tx: TransactionResponse;
+      given(async () => {
+        await transformerOracle.connect(admin).avoidMappingToUnderlying([TOKEN_A]);
+        tx = await transformerOracle.connect(admin).shouldMapToUnderlying([TOKEN_A]);
+      });
+      then('token will not avoid mapping', async () => {
+        const willAvoid = await transformerOracle.willAvoidMappingToUnderlying(TOKEN_A);
+        expect(willAvoid).to.be.false;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(transformerOracle, 'DependentsWillMapToUnderlying').withArgs([TOKEN_A]);
+      });
+    });
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => transformerOracle,
+      funcAndSignature: 'shouldMapToUnderlying',
+      params: [[TOKEN_A]],
+      addressWithRole: () => admin,
+      role: () => adminRole,
+    });
   });
 
   executeRedirectTest({
@@ -187,6 +263,149 @@ describe('TransformerOracle', () => {
   executeRedirectTest({
     func: 'addSupportForPairIfNeeded',
     params: (mappedTokenA, mappedTokenB) => [mappedTokenA, mappedTokenB, BYTES],
+  });
+
+  describe('quote', () => {
+    const AMOUNT_IN = 1000000;
+    given(async () => {
+      // UNDERLYING_TOKEN_A = DEPENDENT_TOKEN_A * 2
+      transformerA.calculateTransformToUnderlying.returns(({ amountDependent }: { amountDependent: BigNumber }) => [
+        { underlying: UNDERLYING_TOKEN_A, amount: amountDependent.mul(2) },
+      ]);
+
+      // UNDERLYING_TOKEN_B = DEPENDENT_TOKEN_B * 5
+      transformerB.calculateTransformToDependent.returns(({ underlying }: { underlying: { amount: BigNumber }[] }) =>
+        underlying[0].amount.div(5)
+      );
+
+      // UNDERLYING_TOKEN_A = UNDERLYING_TOKEN_B * 10
+      underlyingOracle.quote.returns(({ amountIn }: { amountIn: BigNumber }) => amountIn.div(10));
+
+      // Set transformers
+      await transformerOracle.setTransformersForPair(TOKEN_A, TOKEN_B, transformerA.address, transformerB.address);
+      await transformerOracle.setTransformersForPair(TOKEN_A, UNDERLYING_TOKEN_B, transformerA.address, constants.AddressZero);
+      await transformerOracle.setTransformersForPair(UNDERLYING_TOKEN_A, TOKEN_B, constants.AddressZero, transformerB.address);
+      await transformerOracle.setTransformersForPair(UNDERLYING_TOKEN_A, UNDERLYING_TOKEN_B, constants.AddressZero, constants.AddressZero);
+    });
+    when('token in and token out have to be transformed', () => {
+      let returnedQuote: BigNumber;
+      given(async () => {
+        returnedQuote = await transformerOracle.quote(TOKEN_A, AMOUNT_IN, TOKEN_B, BYTES);
+      });
+      then('transformer for token in was called correctly', () => {
+        expect(transformerA.calculateTransformToUnderlying).to.have.been.calledOnceWith(TOKEN_A, AMOUNT_IN);
+      });
+      then('transformer for token out was called for underlyings correctly', () => {
+        expect(transformerB.getUnderlying).to.have.been.calledOnceWith(TOKEN_B);
+      });
+      then('underlying oracle was called correctly', () => {
+        // UNDERLYING_TOKEN_A = DEPENDENT_TOKEN_A * 2
+        expect(underlyingOracle.quote).to.have.been.calledOnceWith(UNDERLYING_TOKEN_A, AMOUNT_IN * 2, UNDERLYING_TOKEN_B, BYTES);
+      });
+      then('transformer for token out was called to calculate transform to dependent correctly', () => {
+        expect(transformerB.calculateTransformToDependent).to.have.been.calledOnce;
+        const call = transformerB.calculateTransformToDependent.getCall(0);
+        const [dependent, underlying]: [string, ITransformer.UnderlyingAmountStruct[]] = call.args as any;
+        expect(dependent).to.equal(TOKEN_B);
+        expect(underlying).to.have.lengthOf(1);
+        expect(underlying[0].underlying).to.equal(UNDERLYING_TOKEN_B);
+        /*
+         UNDERLYING_TOKEN_B = UNDERLYING_TOKEN_A / 10
+                            = DEPENDENT_TOKEN_A * 2 / 10
+                            = DEPENDENT_TOKEN_A / 5
+         */
+        expect(underlying[0].amount).to.equal(AMOUNT_IN / 5);
+      });
+      then('returned quote is as expected', () => {
+        /*
+         DEPENDENT_TOKEN_B = UNDERLYING_TOKEN_B / 5
+                           = UNDERLYING_TOKEN_A / 10 / 5
+                           = DEPENDENT_TOKEN_A * 2 / 10 / 5
+                           = DEPENDENT_TOKEN_A / 25
+        */
+        expect(returnedQuote).to.equal(AMOUNT_IN / 25);
+      });
+    });
+    when('token in has to be transformed', () => {
+      let returnedQuote: BigNumber;
+      given(async () => {
+        returnedQuote = await transformerOracle.quote(TOKEN_A, AMOUNT_IN, UNDERLYING_TOKEN_B, BYTES);
+      });
+      then('transformer for token in was called correctly', () => {
+        expect(transformerA.calculateTransformToUnderlying).to.have.been.calledOnceWith(TOKEN_A, AMOUNT_IN);
+      });
+      then('transformer for token out was not called', () => {
+        expect(transformerB.getUnderlying).to.not.have.been.called;
+        expect(transformerB.calculateTransformToDependent).to.not.have.been.called;
+      });
+      then('underlying oracle was called correctly', () => {
+        // UNDERLYING_TOKEN_A = DEPENDENT_TOKEN_A * 2
+        expect(underlyingOracle.quote).to.have.been.calledOnceWith(UNDERLYING_TOKEN_A, AMOUNT_IN * 2, UNDERLYING_TOKEN_B, BYTES);
+      });
+      then('returned quote is as expected', () => {
+        /* 
+         UNDERLYING_TOKEN_B = UNDERLYING_TOKEN_A / 10 
+                            = DEPENDENT_TOKEN_A * 2 / 10 
+                            = DEPENDENT_TOKEN_A / 5
+         */
+        expect(returnedQuote).to.equal(AMOUNT_IN / 5);
+      });
+    });
+    when('token out has be transformed', () => {
+      let returnedQuote: BigNumber;
+      given(async () => {
+        returnedQuote = await transformerOracle.quote(UNDERLYING_TOKEN_A, AMOUNT_IN, TOKEN_B, BYTES);
+      });
+      then('transformer for token out was called for underlyings correctly', () => {
+        expect(transformerB.getUnderlying).to.have.been.calledOnceWith(TOKEN_B);
+      });
+      then('underlying oracle was called correctly', () => {
+        expect(underlyingOracle.quote).to.have.been.calledOnceWith(UNDERLYING_TOKEN_A, AMOUNT_IN, UNDERLYING_TOKEN_B, BYTES);
+      });
+      then('transformer for token in was not called', () => {
+        expect(transformerA.getUnderlying).to.not.have.been.called;
+        expect(transformerA.calculateTransformToUnderlying).to.not.have.been.called;
+      });
+      then('transformer for token out was called to calculate transform to dependent correctly', () => {
+        expect(transformerB.calculateTransformToDependent).to.have.been.calledOnce;
+        const call = transformerB.calculateTransformToDependent.getCall(0);
+        const [dependent, underlying]: [string, ITransformer.UnderlyingAmountStruct[]] = call.args as any;
+        expect(dependent).to.equal(TOKEN_B);
+        expect(underlying).to.have.lengthOf(1);
+        expect(underlying[0].underlying).to.equal(UNDERLYING_TOKEN_B);
+        // UNDERLYING_TOKEN_B = UNDERLYING_TOKEN_A / 10
+        expect(underlying[0].amount).to.equal(AMOUNT_IN / 10);
+      });
+      then('returned quote is as expected', () => {
+        /* 
+         DEPENDENT_TOKEN_B = UNDERLYING_TOKEN_B / 5
+                           = UNDERLYING_TOKEN_A / 10 / 5
+                           = UNDERLYING_TOKEN_A / 50
+         */
+        expect(returnedQuote).to.equal(AMOUNT_IN / 50);
+      });
+    });
+    when('neither of the tokens has to be transformed', () => {
+      let returnedQuote: BigNumber;
+      given(async () => {
+        returnedQuote = await transformerOracle.quote(UNDERLYING_TOKEN_A, AMOUNT_IN, UNDERLYING_TOKEN_B, BYTES);
+      });
+      then('transformer for token in was not called', () => {
+        expect(transformerA.getUnderlying).to.not.have.been.called;
+        expect(transformerA.calculateTransformToUnderlying).to.not.have.been.called;
+      });
+      then('transformer for token out was not called', () => {
+        expect(transformerB.getUnderlying).to.not.have.been.called;
+        expect(transformerB.calculateTransformToDependent).to.not.have.been.called;
+      });
+      then('underlying oracle was called correctly', () => {
+        expect(underlyingOracle.quote).to.have.been.calledOnceWith(UNDERLYING_TOKEN_A, AMOUNT_IN, UNDERLYING_TOKEN_B, BYTES);
+      });
+      then('returned quote is as expected', () => {
+        // UNDERLYING_TOKEN_B = UNDERLYING_TOKEN_A / 10
+        expect(returnedQuote).to.equal(AMOUNT_IN / 10);
+      });
+    });
   });
 
   describe('supportsInterface', () => {
@@ -213,10 +432,83 @@ describe('TransformerOracle', () => {
         inheritedFrom: [ITokenPriceOracle__factory.createInterface()],
       },
     });
+    behaviours.shouldSupportInterface({
+      contract: () => transformerOracle,
+      interfaceName: 'IAccessControl',
+      interface: IAccessControl__factory.createInterface(),
+    });
     behaviours.shouldNotSupportInterface({
       contract: () => transformerOracle,
       interfaceName: 'IERC20',
       interface: IERC20__factory.createInterface(),
+    });
+  });
+
+  describe('_getTransformers', () => {
+    given(() => {
+      registry.transformers.returns(({ dependents }: { dependents: string[] }) =>
+        dependents.map((dependent) => {
+          switch (dependent) {
+            case TOKEN_A:
+              return UNDERLYING_TOKEN_A;
+            case TOKEN_B:
+              return UNDERLYING_TOKEN_B;
+            default:
+              throw new Error('WTF');
+          }
+        })
+      );
+    });
+    when('tokenA and tokenB should not be mapped', () => {
+      let transformers: string[];
+      given(async () => {
+        await transformerOracle.connect(admin).avoidMappingToUnderlying([TOKEN_A, TOKEN_B]);
+        transformers = await transformerOracle.internalGetTransformers(TOKEN_A, TOKEN_B);
+      });
+      then('registry is never called', () => {
+        expect(registry.transformers).to.not.have.been.called;
+      });
+      then('zero addresses are returned', () => {
+        expect(transformers).to.eql([constants.AddressZero, constants.AddressZero]);
+      });
+    });
+    when('tokenA should not be mapped', () => {
+      let transformers: string[];
+      given(async () => {
+        await transformerOracle.connect(admin).avoidMappingToUnderlying([TOKEN_A]);
+        transformers = await transformerOracle.internalGetTransformers(TOKEN_A, TOKEN_B);
+      });
+      then('registry is called for tokenB', () => {
+        expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_B]);
+      });
+      then('tokenB is mapped', () => {
+        expect(transformers).to.eql([constants.AddressZero, UNDERLYING_TOKEN_B]);
+      });
+    });
+    when('tokenB should not be mapped', () => {
+      let transformers: string[];
+      given(async () => {
+        await transformerOracle.connect(admin).avoidMappingToUnderlying([TOKEN_B]);
+        transformers = await transformerOracle.internalGetTransformers(TOKEN_A, TOKEN_B);
+      });
+      then('registry is called for tokenA', () => {
+        expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_A]);
+      });
+      then('tokenA is mapped', () => {
+        expect(transformers).to.eql([UNDERLYING_TOKEN_A, constants.AddressZero]);
+      });
+    });
+    when('both should be mapped', () => {
+      let transformers: string[];
+      given(async () => {
+        transformers = await transformerOracle.internalGetTransformers(TOKEN_A, TOKEN_B);
+      });
+      then('registry is called for tokenA and tokenB', () => {
+        expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_A, TOKEN_B]);
+      });
+      then('both tokens are mapped', () => {
+        expect(transformers).to.eql([UNDERLYING_TOKEN_A, UNDERLYING_TOKEN_B]);
+      });
     });
   });
 
@@ -255,7 +547,7 @@ describe('TransformerOracle', () => {
       when(title, () => {
         let returned: any;
         given(async () => {
-          await transformerOracle.setUnderlying(TOKEN_A, TOKEN_B, mappedA, mappedB);
+          await transformerOracle.setMappingForPair(TOKEN_A, TOKEN_B, mappedA, mappedB);
           if (returns) {
             underlyingOracle[func].returns(returns);
           }


### PR DESCRIPTION
We are now implementing `canSupportPair`, `isPairAlreadySupported`, `addOrModifySupportForPair` and `addSupportForPairIfNeeded`