### PR TITLE
refactor: check config before calling registry

### DIFF
--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,5 @@
 {
   "exclude_low": true,
-  "detectors_to_exclude": "conformance-to-solidity-naming-conventions,incorrect-versions-of-solidity,variable-names-are-too-similar",
+  "detectors_to_exclude": "conformance-to-solidity-naming-conventions,incorrect-versions-of-solidity,similar-names",
   "filter_paths": "node_modules|openzeppelin|interfaces"
 }

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,5 @@
 {
   "exclude_low": true,
-  "detectors_to_exclude": "conformance-to-solidity-naming-conventions,incorrect-versions-of-solidity,similar-names",
+  "detectors_to_exclude": "conformance-to-solidity-naming-conventions,incorrect-versions-of-solidity,similar-names,solc-version",
   "filter_paths": "node_modules|openzeppelin|interfaces"
 }

--- a/solidity/contracts/TransformerOracle.sol
+++ b/solidity/contracts/TransformerOracle.sol
@@ -159,10 +159,10 @@ contract TransformerOracle is BaseOracle, AccessControl, ITransformerOracle {
         _transformers[0] = ITransformer(address(0));
         _transformers[1] = ITransformer(address(0));
       } else if (_avoidMappingA) {
+        _transformers[0] = ITransformer(address(0));
         address[] memory _tokens = new address[](1);
         _tokens[0] = _tokenB;
         ITransformer[] memory _returnedTransformers = REGISTRY.transformers(_tokens);
-        _transformers[0] = ITransformer(address(0));
         _transformers[1] = _returnedTransformers[0];
       } else {
         address[] memory _tokens = new address[](1);

--- a/solidity/contracts/test/TransformerOracle.sol
+++ b/solidity/contracts/test/TransformerOracle.sol
@@ -5,6 +5,7 @@ import '../TransformerOracle.sol';
 
 contract TransformerOracleMock is TransformerOracle {
   mapping(address => mapping(address => address[])) internal _mappingForPair;
+  mapping(address => mapping(address => ITransformer[])) internal _transformersForPair;
 
   constructor(
     ITransformerRegistry _registry,
@@ -21,6 +22,28 @@ contract TransformerOracleMock is TransformerOracle {
   ) external {
     _mappingForPair[_tokenA][_tokenB].push(_mappedTokenA);
     _mappingForPair[_tokenA][_tokenB].push(_mappedTokenB);
+  }
+
+  function setTransformersForPair(
+    address _tokenA,
+    address _tokenB,
+    ITransformer _transformerTokenA,
+    ITransformer _transformerTokenB
+  ) external {
+    _transformersForPair[_tokenA][_tokenB] = [_transformerTokenA, _transformerTokenB];
+  }
+
+  function internalGetTransformers(address _tokenA, address _tokenB) external view returns (ITransformer[] memory) {
+    return _getTransformers(_tokenA, _tokenB);
+  }
+
+  function _getTransformers(address _tokenA, address _tokenB) internal view override returns (ITransformer[] memory) {
+    ITransformer[] memory _transformers = _transformersForPair[_tokenA][_tokenB];
+    if (_transformers.length > 0) {
+      return _transformers;
+    } else {
+      return super._getTransformers(_tokenA, _tokenB);
+    }
   }
 
   function getMappingForPair(address _tokenA, address _tokenB) public view override returns (address _mappedTokenA, address _mappedTokenB) {

--- a/solidity/contracts/test/TransformerOracle.sol
+++ b/solidity/contracts/test/TransformerOracle.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../TransformerOracle.sol';
 
 contract TransformerOracleMock is TransformerOracle {
-  mapping(address => mapping(address => address[])) internal _underlyingPair;
+  mapping(address => mapping(address => address[])) internal _mappingForPair;
 
   constructor(
     ITransformerRegistry _registry,
@@ -13,27 +13,22 @@ contract TransformerOracleMock is TransformerOracle {
     address[] memory _initialAdmins
   ) TransformerOracle(_registry, _underlyingOracle, _superAdmin, _initialAdmins) {}
 
-  function setUnderlying(
+  function setMappingForPair(
     address _tokenA,
     address _tokenB,
-    address _underlyingTokenA,
-    address _underlyingTokenB
+    address _mappedTokenA,
+    address _mappedTokenB
   ) external {
-    _underlyingPair[_tokenA][_tokenB].push(_underlyingTokenA);
-    _underlyingPair[_tokenA][_tokenB].push(_underlyingTokenB);
+    _mappingForPair[_tokenA][_tokenB].push(_mappedTokenA);
+    _mappingForPair[_tokenA][_tokenB].push(_mappedTokenB);
   }
 
-  function mapPairToUnderlying(address _tokenA, address _tokenB)
-    public
-    view
-    override
-    returns (address _underlyingTokenA, address _underlyingTokenB)
-  {
-    address[] memory _underlying = _underlyingPair[_tokenA][_tokenB];
-    if (_underlying.length == 0) {
-      return super.mapPairToUnderlying(_tokenA, _tokenB);
+  function getMappingForPair(address _tokenA, address _tokenB) public view override returns (address _mappedTokenA, address _mappedTokenB) {
+    address[] memory _mapping = _mappingForPair[_tokenA][_tokenB];
+    if (_mapping.length == 0) {
+      return super.getMappingForPair(_tokenA, _tokenB);
     } else {
-      return (_underlying[0], _underlying[1]);
+      return (_mapping[0], _mapping[1]);
     }
   }
 }

--- a/solidity/interfaces/ITransformerOracle.sol
+++ b/solidity/interfaces/ITransformerOracle.sol
@@ -50,15 +50,16 @@ interface ITransformerOracle is ITokenPriceOracle {
   function willAvoidMappingToUnderlying(address dependent) external view returns (bool);
 
   /**
-   * @notice Takes a pair of tokens, and checks if any of them is registered as a dependent on the registry.
-   *         If any of them are, then they are transformed to their underlying tokens. If they aren't, then
-   *         they are simply returned
+   * @notice Takes a pair of tokens, and maps them to their underlying counterparts if they exist, and if they
+   *         haven't been configured to avoid mapping
    * @param tokenA One of the pair's tokens
    * @param tokenB The other of the pair's tokens
-   * @return underlyingTokenA tokenA's underlying token (if exists), or tokenA if there is no underlying token
-   * @return underlyingTokenB tokenB's underlying token (if exists), or tokenB if there is no underlying token
+   * @return mappedTokenA tokenA's underlying token, if exists and isn't configured to avoid mapping.
+   *                      Otherwise tokenA
+   * @return mappedTokenB tokenB's underlying token, if exists and isn't configured to avoid mapping.
+   *                      Otherwise tokenB
    */
-  function mapPairToUnderlying(address tokenA, address tokenB) external view returns (address underlyingTokenA, address underlyingTokenB);
+  function getMappingForPair(address tokenA, address tokenB) external view returns (address mappedTokenA, address mappedTokenB);
 
   /**
    * @notice Determines that the given dependents will avoid mapping to their underlying counterparts, and


### PR DESCRIPTION
Now, before calling the registry to get the tokens' transformers,  we are checking the config to see if we should map the pair or not. If not, then we act as if there were no transformers at all.

We also renamed `mapPairToUnderlying` to `getMappingForPair`, since it makes more sense now