### PR TITLE
feat: add sort by liquidity

### DIFF
--- a/solidity/contracts/test/adapters/UniswapV3Adapter.sol
+++ b/solidity/contracts/test/adapters/UniswapV3Adapter.sol
@@ -14,6 +14,10 @@ contract UniswapV3AdapterMock is UniswapV3Adapter {
     _addOrModifySupportForPair(_tokenA, _tokenB, _data);
   }
 
+  function internalGetAllPoolsSortedByLiquidity(address _tokenA, address _tokenB) external view returns (address[] memory) {
+    return _getAllPoolsSortedByLiquidity(_tokenA, _tokenB);
+  }
+
   function setPools(
     address _tokenA,
     address _tokenB,


### PR DESCRIPTION
We are now adding `_getAllPoolsSortedByLiquidity` to the Uniswap v3 adapter. This function will take a pair, get all existing pools and sort them by liquidity, desc, and return them.

This is the first step of our plan towards avoiding the run out of gas issue